### PR TITLE
Removes decidim-consultations as a mandatory dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,16 @@ This [Decidim](https://github.com/decidim/decidim) module enable a multitenant g
 
 Edit the Gemfile and add this lines:
 
-**NOTE: decidim-consultations is required**
+**NOTE: decidim-consultations is optional**
 
 ```ruby
 gem "decidim-calendar"
-gem "decidim-consultations"
 ```
 
 Run this rake tasks:
 
 ```bash
 bundle exec rake decidim_calendar:install:migrations
-bundle exec rake decidim_consultations:install:migrations
 bundle exec rake db:migrate
 ```
 

--- a/app/controllers/decidim/calendar/calendar_controller.rb
+++ b/app/controllers/decidim/calendar/calendar_controller.rb
@@ -8,7 +8,11 @@ module Decidim
       layout "calendar"
       def index
         @events = Event.all(current_organization)
-        @resources = %w(consultation debate external_event meeting participatory_step)
+	if defined? Decidim::Consultation
+          @resources = %w(consultation debate external_event meeting participatory_step)
+	else
+          @resources = %w(debate external_event meeting participatory_step)
+	end
       end
 
       def gantt

--- a/app/models/decidim/calendar/event.rb
+++ b/app/models/decidim/calendar/event.rb
@@ -4,13 +4,22 @@ module Decidim
   module Calendar
     module Event
 
-      MODELS = [
-        Decidim::Meetings::Meeting,
-        Decidim::ParticipatoryProcessStep,
-        Decidim::Debates::Debate,
-        Decidim::Consultation,
-        Decidim::Calendar::ExternalEvent
-      ].freeze
+      if defined? Decidim::Consultation
+        MODELS = [
+          Decidim::Meetings::Meeting,
+          Decidim::ParticipatoryProcessStep,
+          Decidim::Debates::Debate,
+          Decidim::Consultation,
+          Decidim::Calendar::ExternalEvent
+        ].freeze
+      else
+        MODELS = [
+          Decidim::Meetings::Meeting,
+          Decidim::ParticipatoryProcessStep,
+          Decidim::Debates::Debate,
+          Decidim::Calendar::ExternalEvent
+        ].freeze
+      end
 
       def self.all(current_organization)
         events = []

--- a/app/views/decidim/calendar/calendar/index.html.erb
+++ b/app/views/decidim/calendar/calendar/index.html.erb
@@ -13,7 +13,11 @@
 <%= stylesheet_link_tag "decidim/calendar/calendar" %>
 
  <script>
+   <% if defined? Decidim::Consultation %>
    let filters = ["consultation", "external_event", "meeting", "debate", "participatory_step"];
+   <% else %>
+   let filters = ["external_event", "meeting", "debate", "participatory_step"];
+   <% end %>
 
    function removeFilter(filters, filter){
      return filters.filter((element) => element !== filter)

--- a/decidim-calendar.gemspec
+++ b/decidim-calendar.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-admin", Decidim::Calendar.version
-  s.add_dependency "decidim-consultations", Decidim::Calendar.version
   s.add_dependency "decidim-core", Decidim::Calendar.version
 end


### PR DESCRIPTION
Some installations may not have decidim-consultations, as is a optional module, not enabled by default. 
This removes this hard-dependency and makes it optional. 